### PR TITLE
update_for_macos_sierra

### DIFF
--- a/lib/puppet/provider/mac_hide_user/osx.rb
+++ b/lib/puppet/provider/mac_hide_user/osx.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:mac_hide_user).provide(:osx) do
   desc "Hides the user from the login window specified in the namevar"
   confine :operatingsystem => :darwin
-  confine :macosx_productversion_major => ["10.10", "10.11"]
+  confine :macosx_productversion_major => ["10.10", "10.11", "10.12"]
 
   defaultfor :operatingsystem => :darwin
 

--- a/manifests/sus.pp
+++ b/manifests/sus.pp
@@ -27,6 +27,7 @@ class mac_admin::sus(
     $sus_url_109 = undef,
     $sus_url_1010 = undef,
     $sus_url_1011 = undef,
+    $sus_url_1012 = undef
     ) inherits mac_admin::params {
     ## Set the url for each OS
     case $::macosx_productversion_major {
@@ -58,6 +59,12 @@ class mac_admin::sus(
         '10.11':{
             if $sus_url_1011!=false{
                 $sus_url = $sus_url_1011
+            }
+        }
+        
+        '10.12':{
+            if $sus_url_1012!=false{
+                $sus_url = $sus_url_1012
             }
         }
     }


### PR DESCRIPTION
Hi,
  before the changes, puppet agent failed right at the start on Macos Sierra:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Function Call, Unsupported version of OS X. at /etc/puppetlabs/code/environments/production/modules/mac_admin/manifests/sus.pp:34:13 on node c02kdfsydncr

   And I worked around it with this command.
echo macosx_productversion_major=10.11 > /etc/facter/facts.d/macosx_productversion_major.txt

   No errors. So the mac_admin module can still work in Macos Sierra, it just needs the new version added to the manifest.

Cheers,
fuzzycheck
